### PR TITLE
Port 10849 documentation for azure devops boards

### DIFF
--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_supported_resources.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/_azuredevops_exporter_supported_resources.mdx
@@ -10,5 +10,6 @@ The following resources can be used to map data from Azure DevOps, it is possibl
 - [`team`](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/teams/get-all-teams?view=azure-devops-rest-7.1&tabs=HTTP#webapiteam)
 - [`member`](https://learn.microsoft.com/en-us/rest/api/azure/devops/core/teams/get-team-members-with-extended-properties?view=azure-devops-rest-7.1&tabs=HTTP#teammember)
 - [`work-item`](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/wiql/query-by-wiql?view=azure-devops-rest-7.1&tabs=HTTP)
+- [`board`](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/boards/list?view=azure-devops-rest-7.1)
 
 :::

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-board/_azuredevops_exporter_example_board_blueprint.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-board/_azuredevops_exporter_example_board_blueprint.mdx
@@ -1,0 +1,34 @@
+<details>
+<summary>Board blueprint</summary>
+
+```json showLineNumbers
+{
+  "identifier": "board",
+  "title": "Board",
+  "icon": "AzureDevops",
+  "schema": {
+    "properties": {
+      "link": {
+        "title": "Link",
+        "type": "string",
+        "format": "url",
+        "icon": "AzureDevops",
+        "description": "Link to the board in Azure DevOps"
+      }
+    },
+    "required": []
+  },
+  "mirrorProperties": {},
+  "calculationProperties": {},
+  "aggregationProperties": {},
+  "relations": {
+    "project": {
+      "title": "Project",
+      "target": "project",
+      "required": true,
+      "many": false
+    }
+  }
+}
+```
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-board/_azuredevops_exporter_example_board_port_app_config.mdx
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/example-board/_azuredevops_exporter_example_board_port_app_config.mdx
@@ -1,0 +1,23 @@
+<details>
+
+<summary>Ocean integration configuration</summary>
+
+```yaml showLineNumbers
+resources:
+  - kind: board
+    selector:
+      query: 'true'
+    port:
+      entity:
+        mappings:
+          identifier: .id | gsub(" "; "")
+          title: .name
+          blueprint: '"board"'
+          properties:
+            link: .url
+          relations:
+            project: .__project.id | gsub(" "; "")
+
+```
+
+</details>

--- a/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
+++ b/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md
@@ -19,6 +19,10 @@ import ProjectBlueprint from './example-project/\_azuredevops_exporter_example_p
 import WorkItemBlueprint from './example-project/\_azuredevops_exporter_example_work_item_blueprint.mdx'
 import PortWorkItemAppConfig from './example-project/\_azuredevops_exporter_example_work_item_port_app_config.mdx'
 
+import BoardBlueprint from './example-board/\_azuredevops_exporter_example_board_blueprint.mdx'
+import PortBoardAppConfig from './example-board/\_azuredevops_exporter_example_board_port_app_config.mdx'
+
+
 # Examples
 
 ## Mapping projects
@@ -117,8 +121,28 @@ In the following example you will ingest your Azure Devops work items to Port, y
 
 - Click [Here](https://learn.microsoft.com/en-us/rest/api/azure/devops/wit/work-items/list?view=azure-devops-rest-7.1&tabs=HTTP#get-list-of-work-items) for the Azure Devops work item object structure.
 - Click [Here](https://learn.microsoft.com/en-us/azure/devops/boards/queries/wiql-syntax?view=azure-devops#example-clauses) for WIQL clauses
-
 :::
+
+
+## Mapping boards
+
+In the following example, you'll learn how to ingest Azure DevOps Boards into Port.  you may use the following Port blueprint definitions and integration configuration: 
+
+<ProjectBlueprint/>
+
+<BoardBlueprint/>
+
+<PortBoardAppConfig/>
+
+
+:::tip To Learn More
+- Refer to the [setup](azure-devops.md#setup) section to learn more about the integration configuration setup process.
+- We leverage [JQ JSON processor](https://stedolan.github.io/jq/manual/) to map and transform Azure DevOps objects to Port entities.
+- Click [here](https://learn.microsoft.com/en-us/rest/api/azure/devops/work/boards/list?view=azure-devops-rest-7.1) for the Azure DevOps board object structure.
+:::
+
+After creating the blueprints and saving the integration configuration, you will see new entities in Port matching your Azure DevOps boards.
+
 
 ## Mapping supported resources
 


### PR DESCRIPTION
# Description

Documentation for the new feature that allows users to bring Azure Devops boards data to Port. This documentation will act as a guide for mapping Azure devops board to port.


## Updated docs pages

Please also include the path for the updated docs

- Examples(`/docs/build-your-software-catalog/sync-data-to-catalog/git/azure-devops/examples.md]`)

